### PR TITLE
🟠 Normal: StyleGuideTheme defaults [Small]

### DIFF
--- a/Sources/CubeStyleGuide/Model/StyleGuideTheme.swift
+++ b/Sources/CubeStyleGuide/Model/StyleGuideTheme.swift
@@ -11,20 +11,20 @@ import CubeFoundationSwiftUI
 
 public struct StyleGuideTheme {
 
-    var primaryTextStyle: TextStyle
-    var secondaryTextStyle: TextStyle
-    var backgroundColor: Color
-    var primaryColor: Color
-    var secondaryColor: Color
-    var accentColor: Color
+    public var primaryTextStyle: TextStyle
+    public var secondaryTextStyle: TextStyle
+    public var backgroundColor: Color
+    public var primaryColor: Color
+    public var secondaryColor: Color
+    public var accentColor: Color
 
     public init(
-        primaryTextStyle: TextStyle,
-        secondaryTextStyle: TextStyle,
-        backgroundColor: Color,
-        primaryColor: Color,
-        secondaryColor: Color,
-        accentColor: Color
+        primaryTextStyle: TextStyle = Self.default.primaryTextStyle,
+        secondaryTextStyle: TextStyle = Self.default.secondaryTextStyle,
+        backgroundColor: Color = Self.default.backgroundColor,
+        primaryColor: Color = Self.default.primaryColor,
+        secondaryColor: Color = Self.default.secondaryColor,
+        accentColor: Color = Self.default.accentColor
     ) {
         self.primaryTextStyle = primaryTextStyle
         self.secondaryTextStyle = secondaryTextStyle
@@ -38,11 +38,11 @@ public struct StyleGuideTheme {
 public extension StyleGuideTheme {
 
     static let `default` = StyleGuideTheme(
-        primaryTextStyle: TextStyle(font: .helveticaNeue, weight: 800, size: 10, lineHeight: 10),
-        secondaryTextStyle: TextStyle(font: .helveticaNeue, weight: 700, size: 12, lineHeight: 10),
-        backgroundColor: Color(.sRGB, red: 1.0, green: 1.0, blue: 1.0),
-        primaryColor: Color(.sRGB, red: 0.2, green: 0.2, blue: 0.2),
-        secondaryColor: Color(.sRGB, red: 0.96, green: 0.96, blue: 0.96),
-        accentColor: Color(.sRGB, red: 1.0, green: 0.86, blue: 0.86)
+        primaryTextStyle: .primary,
+        secondaryTextStyle: .secondary,
+        backgroundColor: .background,
+        primaryColor: .primary,
+        secondaryColor: .secondary,
+        accentColor: .accent
     )
 }

--- a/Sources/CubeStyleGuide/Values/Color+Colors.swift
+++ b/Sources/CubeStyleGuide/Values/Color+Colors.swift
@@ -1,0 +1,17 @@
+//
+//  Color+Colors.swift
+//  CubeStyleGuide
+//
+//  Created by Sam Davis on 22/02/2023.
+//  Copyright © 2023 3 SIDED CUBE APP PRODUCTIONS LTD. All rights reserved.
+//
+
+import SwiftUI
+
+extension Color {
+
+    static let background = Color(.sRGB, red: 1.0, green: 1.0, blue: 1.0)
+    static let primary = Color(.sRGB, red: 0.2, green: 0.2, blue: 0.2)
+    static let secondary = Color(.sRGB, red: 0.96, green: 0.96, blue: 0.96)
+    static let accent = Color(.sRGB, red: 1.0, green: 0.86, blue: 0.86)
+}

--- a/Sources/CubeStyleGuide/Values/TextStyle+Styles.swift
+++ b/Sources/CubeStyleGuide/Values/TextStyle+Styles.swift
@@ -1,0 +1,16 @@
+//
+//  TextStyle+Styles.swift
+//  CubeStyleGuide
+//
+//  Created by Sam Davis on 22/02/2023.
+//  Copyright © 2023 3 SIDED CUBE APP PRODUCTIONS LTD. All rights reserved.
+//
+
+import SwiftUI
+import CubeFoundationSwiftUI
+
+extension TextStyle {
+
+    static let primary = TextStyle(font: .helveticaNeue, weight: 800, size: 10, lineHeight: 10)
+    static let secondary = TextStyle(font: .helveticaNeue, weight: 700, size: 12, lineHeight: 10)
+}


### PR DESCRIPTION
- Move theme text and colour values into separate files.
- Add default values to `StyleGuideTheme` `init` based on `StyleGuideTheme.default`.