### PR TITLE
🟢 Low: Fix SwiftUI Previews [Small]

### DIFF
--- a/Sources/CubeStyleGuide/Components/ColorSwatchView.swift
+++ b/Sources/CubeStyleGuide/Components/ColorSwatchView.swift
@@ -89,7 +89,7 @@ fileprivate struct SwatchSingleColorView: View {
     }
 }
 
-fileprivate struct ColorSwatchView_Previews: PreviewProvider {
+struct ColorSwatchView_Previews: PreviewProvider {
     static var previews: some View {
         ColorSwatchView(
             swatch: ColorSwatch(

--- a/Sources/CubeStyleGuide/Components/ComponentSwatchView.swift
+++ b/Sources/CubeStyleGuide/Components/ComponentSwatchView.swift
@@ -30,7 +30,7 @@ public struct ComponentSwatchView: View {
     }
 }
 
-fileprivate struct ComponentSwatchView_Previews: PreviewProvider {
+struct ComponentSwatchView_Previews: PreviewProvider {
     static var previews: some View {
         ComponentSwatchView(
             swatch: ComponentSwatch(

--- a/Sources/CubeStyleGuide/Components/LayoutValueView.swift
+++ b/Sources/CubeStyleGuide/Components/LayoutValueView.swift
@@ -32,7 +32,7 @@ public struct LayoutValueView: View {
     }
 }
 
-fileprivate struct LayoutValueView_Previews: PreviewProvider {
+struct LayoutValueView_Previews: PreviewProvider {
     static var previews: some View {
         LayoutValueView(layoutValue: NamedLayoutValue(name: "400", value: 16), theme: .default)
             .frame(width: 75)

--- a/Sources/CubeStyleGuide/Components/MarginLayoutValueView.swift
+++ b/Sources/CubeStyleGuide/Components/MarginLayoutValueView.swift
@@ -37,7 +37,7 @@ public struct MarginLayoutValueView: View {
     }
 }
 
-fileprivate struct MarginLayoutValueView_Previews: PreviewProvider {
+struct MarginLayoutValueView_Previews: PreviewProvider {
     static var previews: some View {
         MarginLayoutValueView(
             layoutValue: NamedLayoutValue(

--- a/Sources/CubeStyleGuide/Components/ShadowSwatchView.swift
+++ b/Sources/CubeStyleGuide/Components/ShadowSwatchView.swift
@@ -28,7 +28,7 @@ public struct ShadowSwatchView: View {
     }
 }
 
-fileprivate struct ShadowSwatchView_Previews: PreviewProvider {
+struct ShadowSwatchView_Previews: PreviewProvider {
     static var previews: some View {
         ShadowSwatchView(
             shadow: NamedShadow(

--- a/Sources/CubeStyleGuide/Components/StyleGuideHeadingView.swift
+++ b/Sources/CubeStyleGuide/Components/StyleGuideHeadingView.swift
@@ -24,7 +24,7 @@ public struct StyleGuideHeadingView: View {
     }
 }
 
-fileprivate struct UIStyleGuideHeadingView_Previews: PreviewProvider {
+struct UIStyleGuideHeadingView_Previews: PreviewProvider {
     static var previews: some View {
         StyleGuideHeadingView(text: "UI Style Guide Header", theme: .default)
     }

--- a/Sources/CubeStyleGuide/Components/StyleGuideSubheadingView.swift
+++ b/Sources/CubeStyleGuide/Components/StyleGuideSubheadingView.swift
@@ -26,7 +26,7 @@ public struct StyleGuideSubheadingView: View {
     }
 }
 
-fileprivate struct StyleGuideSubheadingView_Previews: PreviewProvider {
+struct StyleGuideSubheadingView_Previews: PreviewProvider {
     static var previews: some View {
         StyleGuideSubheadingView(text: "Subheading", theme: .default)
     }

--- a/Sources/CubeStyleGuide/Components/TextStyleSwatchView.swift
+++ b/Sources/CubeStyleGuide/Components/TextStyleSwatchView.swift
@@ -29,7 +29,7 @@ public struct TextStyleSwatchView: View {
     }
 }
 
-fileprivate struct TextStyleView_Previews: PreviewProvider {
+struct TextStyleView_Previews: PreviewProvider {
     static var previews: some View {
         TextStyleSwatchView(
             swatch: TextStyleSwatch(


### PR DESCRIPTION
Fixes SwiftUI Previews not working due to 'unknown preview provider' error.
This was caused by having the `PreviewProvider`s private.